### PR TITLE
BUG: Grammar issue in logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -205,10 +205,10 @@ def main():
     queue = len(ytDL.download_queue)
     if queue > 0:
         if queue > 1:
-            grammar = "videos"
+            grammar = f"There are {queue} videos"
         else:
-            grammar = "video"
-        logger.logMsg(f"There are {queue} {grammar} to download! Starting the download process now...")
+            grammar = f"There is {queue} video"
+        logger.logMsg(f"{grammar} to download! Starting the download process now...")
         ytDL.downloadVideos()
         ytDL.rateVideos(yto._access_token)
     else:

--- a/youtubeDL.py
+++ b/youtubeDL.py
@@ -231,7 +231,7 @@ class youtubeDL():
             url = self.SCHEME + base_url + endpoint
             self._logger.logDebugMsg(f"DEBUG: Calling YouTube API via URL: {url}")
             self._logger.logMsg(f"Starting the download process on video #{ii} through yt-dlp...")
-            redirect = f">> {self.download_path} 2>&1"
+            redirect = f">> {self._PATH}/yt-dlp.log 2>&1"
             cmd = f'{self._YTDLP} --path {self.download_path} --no-progress --format "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]" --output "%(channel)s - %(title)s.%(ext)s" {url}'
             self._logger.logDebugMsg(f"DEBUG: Downloading Video ID: {i} with Command: {cmd}")
             exit_code = os.system(cmd + redirect)


### PR DESCRIPTION
- fixed grammar issue when logging how many videos are in the download queue
- fixed log redirect issue with the yt-dlp command