### PR TITLE
up to 4k video downloads

### DIFF
--- a/youtubeDL.py
+++ b/youtubeDL.py
@@ -26,7 +26,7 @@ class youtubeDL():
     ########################
     SCHEME = "https://"
     BASE_URL = "youtube.googleapis.com"
-    VIDEO_FORMAT = "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]"
+    VIDEO_FORMAT = "bv*[ext=webm]+ba[ext=m4a]/b[ext=webm]"
     VIDEO_NAME = "%(channel)s - %(title)s.%(ext)s"
 
     #######################


### PR DESCRIPTION
the "best" video and audio format has been updated to download the "best" video and audio formats where possible, including 2k (1440p) and 4k, if the video supports those formats